### PR TITLE
BSO sandevistan + loadout fix (Название пояса)

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
@@ -368,6 +368,16 @@
     - BSOManual
 
 - type: selectableSet
+  id: BSOSandevistanSet
+  name: Набор "Сандевистан"
+  description: Имплант, заменяющий сердце, позволяет ускорять тело носителя.
+  sprite:
+    sprite: _Goobstation/Objects/Misc/sandevistan.rsi
+    state: icon
+  content:
+    - OrganHeartSandevistanBSO
+
+- type: selectableSet
   id: BSOChesterSet
   name: selectable-set-blueshield-chester-name
   description: selectable-set-blueshield-chester-description

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/CentralCommand/set_selectors.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/CentralCommand/set_selectors.yml
@@ -31,6 +31,7 @@
     - BSOCQCSet
     - BSOChesterSet
     - BSOSyringeSet
+    - BSOSandevistanSet
     maxSelectedSets: 2
 
 

--- a/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
@@ -999,7 +999,7 @@
 
 - type: loadoutGroup
   id: BlueshieldOfficerBelt
-  name: loadout-group-bso-belt
+  name: Пояс офицера Синего Щита
   loadouts:
   - BeltAssault
   - MilitaryWebbingBlueShield

--- a/Resources/Prototypes/_Mini/Entities/Specific/Implants/implants.yml
+++ b/Resources/Prototypes/_Mini/Entities/Specific/Implants/implants.yml
@@ -27,3 +27,22 @@
   components:
   - type: Implanter
     implant: DeathRattleImplantTypan
+
+- type: entity
+  parent: [ OrganHumanHeart, BaseCentcommContraband ]
+  id: OrganHeartSandevistanBSO
+  name: Офицерский Сандевистан
+  description: Аналог контрабандного импланта Синдиката. Этот сделан для Офицеров "Синий Щит".
+  components:
+  - type: Cybernetics
+  - type: Sprite
+    sprite: _Goobstation/Objects/Misc/sandevistan.rsi
+    state: icon
+    scale: 0.5, 0.5
+  - type: Organ
+    onAdd:
+    - type: SandevistanUser
+      loadPerActiveSecond: 12
+      loadPerInactiveSecond: -6
+      attackSpeedModifer: 1.5
+      movementSpeedModifer: 1.6


### PR DESCRIPTION

## Описание PR
Добавил для ОСЩ личный Сандевистан отдельным набором. Изменил кривое название в персонализации ОСЩ.

## Почему / Баланс
Ну, а чего нет? Бегают рядовые патрульные с сандевистаном на Тайпане - а тут элитный телохранитель с урезанным.
Действует всего 5 секунд.

## Технические детали
Проверил на локалке, работает.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Sandevistan implant set for Blueshield Officers, available through equipment selection.
  * The implant provides enhanced combat capabilities with increased attack and movement speed modifiers.
  * Updated Blueshield Officer loadout naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->