### PR TITLE
Фикс рации + Тестов

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -287,7 +287,7 @@ public sealed partial class RadioSystem : EntitySystem
         var obfuscated = _language.ObfuscateSpeech(content, language);
         // Goobstation - Chat Pings
         // Added GetNetEntity(messageSource), to source
-        var obfuscatedWrapped = WrapRadioMessage(messageSource, channel, name, obfuscated, language, jobIcon, jobName);
+        var obfuscatedWrapped = WrapRadioMessage(messageSource, channel, name, obfuscated, language, jobIcon, jobName, headsetColor, job);
         var notUdsMsg = new ChatMessage(ChatChannel.Radio, obfuscated, obfuscatedWrapped, GetNetEntity(messageSource), null);
         var ev = new RadioReceiveEvent(messageSource, channel, msg, notUdsMsg, language, radioSource);
         // Einstein Engines - Language end
@@ -401,7 +401,9 @@ public sealed partial class RadioSystem : EntitySystem
         string message,
         LanguagePrototype language,
         ProtoId<JobIconPrototype>? jobIcon, // Goob edit
-        string? jobName = null) // Gaby Radio icons
+        string? jobName, // Gaby Radio icons
+        Color headsetColor,
+        string job)
     {
         // TODO: code duplication with ChatSystem.WrapMessage
         var speech = _chat.GetSpeechVerb(source, message);
@@ -446,6 +448,7 @@ public sealed partial class RadioSystem : EntitySystem
         // goob end
 
         return Loc.GetString(wrapId,
+            ("channel-color", channel.Color),
             ("color", channel.Color),
             ("languageColor", languageColor),
             ("fontType", language.SpeechOverride.FontId ?? speech.FontId),
@@ -455,6 +458,8 @@ public sealed partial class RadioSystem : EntitySystem
             ("channel", $"\\[{channel.LocalizedName}\\]"),
             ("name", nameString), // goob
             ("message", message),
+            ("headset-color", headsetColor),
+            ("job", job),
             ("language", languageDisplay));
     }
     // Einstein Engines - Language end

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -225,7 +225,10 @@ public sealed partial class StationJobsSystem
                 foreach (var station in stations)
                 {
                     var share = (int)Math.Floor(((float)stationTotalSlots[station] / totalSlots) * candidates.Count);
-                    stationShares[station] = Math.Min(share, stationTotalSlots[station]);
+                    var selecting = currentlySelectingJobs[station];
+                    var hasUncappedJob = selecting.Values.Any(x => x == null);
+                    var maxShare = hasUncappedJob ? candidates.Count : stationTotalSlots[station];
+                    stationShares[station] = Math.Min(share, maxShare);
                     distributed += stationShares[station];
                 }
 
@@ -235,8 +238,14 @@ public sealed partial class StationJobsSystem
                     var withRoom = new List<EntityUid>();
                     foreach (var station in stations)
                     {
-                        if (stationShares[station] < stationTotalSlots[station])
+                        var selecting = currentlySelectingJobs[station];
+                        var hasUncappedJob = selecting.Values.Any(x => x == null);
+                        if (hasUncappedJob
+                            ? stationShares[station] < candidates.Count
+                            : stationShares[station] < stationTotalSlots[station])
+                        {
                             withRoom.Add(station);
+                        }
                     }
 
                     if (withRoom.Count == 0)

--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -23,6 +23,7 @@ using Content.Shared.Contraband;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
+using Content.Shared.Radio.Components;
 using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using Robust.Shared.Prototypes;
@@ -117,6 +118,13 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
             proto.TryGetComponent("Clothing", out ClothingComponent? otherClothing))
         {
             _clothingSystem.CopyVisuals(uid, otherClothing, clothing);
+        }
+
+        if (TryComp(uid, out HeadsetComponent? headset) &&
+            proto.TryGetComponent(out HeadsetComponent? otherHeadset, Factory))
+        {
+            headset.CopyColorFrom(otherHeadset);
+            Dirty(uid, headset);
         }
 
         // appearance data logic

--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -120,10 +120,14 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
             _clothingSystem.CopyVisuals(uid, otherClothing, clothing);
         }
 
-        if (TryComp(uid, out HeadsetComponent? headset) &&
-            proto.TryGetComponent(out HeadsetComponent? otherHeadset, Factory))
+        if (TryComp(uid, out HeadsetComponent? headset))
         {
-            headset.CopyColorFrom(otherHeadset);
+            if (proto.TryGetComponent(out HeadsetComponent? otherHeadset, Factory))
+                headset.CopyColorFrom(otherHeadset);
+            else
+                headset.ResetColorToDefault();
+
+            Dirty(uid, headset);
         }
 
         // appearance data logic

--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -124,7 +124,6 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
             proto.TryGetComponent(out HeadsetComponent? otherHeadset, Factory))
         {
             headset.CopyColorFrom(otherHeadset);
-            Dirty(uid, headset);
         }
 
         // appearance data logic

--- a/Content.Shared/Radio/Components/HeadsetComponent.cs
+++ b/Content.Shared/Radio/Components/HeadsetComponent.cs
@@ -24,4 +24,9 @@ public sealed partial class HeadsetComponent : Component
 
     [DataField]
     public Color Color { get; private set; } = Color.Lime;
+
+    public void CopyColorFrom(HeadsetComponent other)
+    {
+        Color = other.Color;
+    }
 }

--- a/Content.Shared/Radio/Components/HeadsetComponent.cs
+++ b/Content.Shared/Radio/Components/HeadsetComponent.cs
@@ -5,13 +5,14 @@
 // SPDX-License-Identifier: MIT
 
 using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Radio.Components;
 
 /// <summary>
 ///     This component relays radio messages to the parent entity's chat when equipped.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class HeadsetComponent : Component
 {
     [DataField("enabled")]
@@ -22,11 +23,16 @@ public sealed partial class HeadsetComponent : Component
     [DataField("requiredSlot")]
     public SlotFlags RequiredSlot = SlotFlags.EARS;
 
-    [DataField]
-    public Color Color { get; private set; } = Color.Lime;
+    [DataField, AutoNetworkedField]
+    public Color Color = Color.Lime;
 
     public void CopyColorFrom(HeadsetComponent other)
     {
         Color = other.Color;
+    }
+
+    public void ResetColorToDefault()
+    {
+        Color = Color.Lime;
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
<!-- Что вы изменили? -->
Заметил, что гарнитура-хамелион в цвете должности в рации игнорирует состояние хамелиона. Теперь цвет должности хамелионовской гарнитуры работает нормально. Ну и правка для тестов, снова

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Гарнитура хамелион не должна так глупо палиться.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
<img width="1920" height="1080" alt="изображение" src="https://github.com/user-attachments/assets/7a4f9767-0adc-455d-8679-4c6f871e3a94" />


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- fix: Гарнитура-хамелион теперь корректно отображает свой цвет в чате рации.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Station job assignment now correctly handles stations with flexible or unrestricted job openings during distribution.
* Chameleon clothing now properly synchronizes headset colors when copying visual properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->