### PR TITLE
Исправление проблем с маньяком-мясником и антагонистами

### DIFF
--- a/Content.Client/Stealth/StealthSystem.cs
+++ b/Content.Client/Stealth/StealthSystem.cs
@@ -83,8 +83,10 @@
 using Content.Client.Interactable.Components;
 using Content.Shared.Stealth;
 using Content.Shared.Stealth.Components;
+using Content.Goobstation.Shared.Slasher.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.Stealth;
@@ -94,6 +96,7 @@ public sealed class StealthSystem : SharedStealthSystem
     private static readonly ProtoId<ShaderPrototype> Shader = "Stealth";
 
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
@@ -169,6 +172,13 @@ public sealed class StealthSystem : SharedStealthSystem
         var reference = args.Viewport.WorldToLocal(_transformSystem.GetWorldPosition(parentXform));
         reference.X = -reference.X;
         var visibility = GetVisibility(uid, component);
+        if (_player.LocalEntity == uid &&
+            TryComp<SlasherIncorporealComponent>(uid, out var slasher) &&
+            slasher.IsIncorporeal)
+        {
+            // Keep slasher readable for its own player only.
+            visibility = MathF.Max(visibility, 0.35f);
+        }
 
         // Goobstation - Proper invisibility: changes -1 to -1.5
         // actual visual visibility effect is limited to -1.5 to 1.

--- a/Content.Goobstation.Shared/Slasher/Systems/SlasherIncorporealSystem.cs
+++ b/Content.Goobstation.Shared/Slasher/Systems/SlasherIncorporealSystem.cs
@@ -34,8 +34,9 @@ using Content.Shared.Standing;
 using Content.Goobstation.Shared.Supermatter.Components;
 using Content.Shared.Body.Part;
 using Content.Shared.Pointing;
+using Content.Goobstation.Shared.Xenomorph;
 using Robust.Shared.Timing;
-using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Goobstation.Shared.Slasher.Systems;
 
@@ -52,6 +53,7 @@ public sealed class SlasherIncorporealSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     private const string FootstepSoundTag = "FootstepSound";
@@ -275,6 +277,7 @@ public sealed class SlasherIncorporealSystem : EntitySystem
 
         // Supermatter immunity
         _ = EnsureComp<SupermatterImmuneComponent>(uid);
+        _ = EnsureComp<FacehuggerImmuneComponent>(uid);
 
         // Raise event for server systems to handle additional logic (like disabling lights)
         var enteredEv = new SlasherIncorporealEnteredEvent();
@@ -318,6 +321,7 @@ public sealed class SlasherIncorporealSystem : EntitySystem
 
         // Remove supermatter immunity
         _ = RemComp<SupermatterImmuneComponent>(uid);
+        _ = RemComp<FacehuggerImmuneComponent>(uid);
     }
 
     // Goida as shit.. I couldn't find a better way stop cooldowns
@@ -509,43 +513,6 @@ public sealed class SlasherIncorporealSystem : EntitySystem
 
     private bool IsInsideSolidObject(EntityUid uid)
     {
-        var entities = _lookup.GetEntitiesInRange(uid, 1f, LookupFlags.Static | LookupFlags.Sundries);
-
-        foreach (var entity in entities)
-        {
-            if (entity == uid)
-                continue;
-
-            // Check if the entity is solid and impassable
-            if (!TryComp<PhysicsComponent>(entity, out var physics))
-                continue;
-
-            if (!physics.CanCollide || !physics.Hard)
-                continue;
-
-            // Check for Impassable collision layer (walls, grilles, etc)
-            if ((physics.CollisionLayer & (int) CollisionGroup.Impassable) != 0)
-                return true;
-
-            // Check for MachineLayer (vending machines, computers, etc)
-            if ((physics.CollisionLayer & (int) CollisionGroup.MidImpassable) != 0 &&
-                (physics.CollisionLayer & (int) CollisionGroup.LowImpassable) != 0)
-                return true;
-
-            // Check for TableLayer (tables)
-            if ((physics.CollisionLayer & (int) CollisionGroup.MidImpassable) != 0 &&
-                (physics.CollisionLayer & (int) CollisionGroup.TableLayer) != 0)
-                return true;
-
-            // Check for TabletopMachineLayer (small machines on tables)
-            if ((physics.CollisionLayer & (int) CollisionGroup.TabletopMachineLayer) != 0)
-                return true;
-
-            // Check for HighImpassable (tall objects)
-            if ((physics.CollisionLayer & (int) CollisionGroup.HighImpassable) != 0)
-                return true;
-        }
-
-        return false;
+        return _physics.GetEntitiesIntersectingBody(uid, (int) CollisionGroup.Impassable).Count > 0;
     }
 }

--- a/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerSystem.cs
+++ b/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerSystem.cs
@@ -33,6 +33,7 @@ using Content.Shared.Throwing;
 using Content.Shared.Atmos.Components;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Nutrition.Components;
+using Content.Goobstation.Shared.Xenomorph;
 
 
 namespace Content.Server._White.Xenomorphs.FaceHugger;
@@ -218,6 +219,8 @@ public sealed class FaceHuggerSystem : EntitySystem
     public bool TryEquipFaceHugger(EntityUid uid, EntityUid target, FaceHuggerComponent component)
     {
         if (!component.Active || _mobState.IsDead(uid) || _entityWhitelist.IsBlacklistPass(component.Blacklist, target))
+            return false;
+        if (HasComp<FacehuggerImmuneComponent>(target))
             return false;
 
         // Check for any blocking masks or equipment

--- a/Resources/Prototypes/_Goobstation/GameRules/Admeme/token.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Admeme/token.yml
@@ -22,6 +22,8 @@
           max: 1
           pickPlayer: false
           startingGear: SpaceNinjaGear
+          skills: # CorvaxGoob-Skills
+            - All
           roleLoadout:
             - RoleSurvivalEVA
           briefing:
@@ -84,6 +86,8 @@
           pickPlayer: false
           startingGear: SyndicateLoneOperativeGearFull
           unequipOldGear: true
+          skills: # CorvaxGoob-Skills
+            - All
           roleLoadout:
             - RoleSurvivalNukie
           components:
@@ -226,6 +230,8 @@
             - MindRoleWizard
           startingGear: WizardGear
           unequipOldGear: true
+          skills: # CorvaxGoob-Skills
+            - All
           roleLoadout:
             - RoleSurvivalEVA
           components:
@@ -338,6 +344,8 @@
           min: 1
           max: 1
           pickPlayer: false
+          skills: # CorvaxGoob-Skills
+            - All
           startingGear: SlasherGear
           roleLoadout:
             - RoleSurvivalEVA


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
<!-- Что вы изменили? -->
Исправил главные проблемы мясника:
1. Ксеноморф больше не прыгает на лицо мясника в бестелесном состоянии
2. Больше нет надоедающей ошибки "Вы не можете материализоваться, пока находитесь на твёрдом объекте!", хотя сам ты стоишь посреди пустой комнаты (она все равно появится, если вы пытаетесь появиться в стене).
3. Игроку на мяснике немного видно "Куклу", чтобы понимать где вообще ты появишься. 
4. Всем токеновым антагонистам выданы все навыки

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
Скрин получился жутким, учитывая, что это вульпа....
<img width="1920" height="1080" alt="изображение" src="https://github.com/user-attachments/assets/ac1ed33d-6693-4ab3-80b9-ad9d1b5b5e74" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

:cl:
- tweak: Игроку за мясника немного видно его куклу в бестелесном состоянии.
- fix: Ксеноморфы больше не прыгают на лицо мясника в бестелесном состоянии.
- fix: Ошибка "Вы не можете материализоваться, пока находитесь на твёрдом объекте!" возникает только если игрок действительно в твердом объекте.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Balance Changes**
  * Adjusted visibility calculations for incorporeal slashers to ensure minimum visibility, preventing complete invisibility during incorporeal state.

* **Bug Fixes**
  * Improved collision detection system for identifying when entities are inside solid objects during incorporeal state.

* **New Features**
  * Added facehugger immunity mechanic when entering incorporeal state; facehuggers can no longer attach to immune entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->