### PR TITLE
Фикс боргов + Лагов

### DIFF
--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -308,7 +308,8 @@ public abstract class SharedEnsnareableSystem : EntitySystem
         if (numEnsnares >= component.MaxEnsnares)
             return false;
 
-        Container.Insert(ensnare, ensnareable.Container);
+        if (!Container.Insert(ensnare, ensnareable.Container))
+            return false;
 
         // Apply stamina damage to target
         if (TryComp<StaminaComponent>(target, out var stamina))

--- a/Content.Shared/_NF/Interaction/Systems/HandPlaceholderSystem.cs
+++ b/Content.Shared/_NF/Interaction/Systems/HandPlaceholderSystem.cs
@@ -110,6 +110,12 @@ public sealed partial class HandPlaceholderSystem : EntitySystem
 
     private void OnEntityRemovedFromContainer(Entity<HandPlaceholderRemoveableComponent> ent, ref EntGotRemovedFromContainerMessage args)
     {
+        if (!TryComp<HandsComponent>(args.Container.Owner, out var hands))
+            return;
+
+        if (!_hands.TryGetHand((args.Container.Owner, hands), args.Container.ID, out _))
+            return;
+
         SwapPlaceholder(ent, args.Container);
     }
 

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Wounding.cs
@@ -1367,9 +1367,6 @@ public sealed partial class WoundSystem
         targeting.BodyStatus = GetWoundableStatesOnBodyPainFeels(bodyPart.Body.Value);
         Dirty(bodyPart.Body.Value, targeting);
 
-        if (_net.IsServer)
-            RaiseNetworkEvent(new TargetIntegrityChangeEvent(GetNetEntity(bodyPart.Body.Value)), bodyPart.Body.Value);
-
         _appearance.SetData(woundable,
             WoundableVisualizerKeys.Wounds,
             new WoundVisualizerGroupData(GetWoundableWounds(woundable).Select(ent => GetNetEntity(ent)).ToList()));


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
<!-- Что вы изменили? -->
1. Борги больше не могут выложить свой слот для предметов в хранилища, получая "руку".
2. Вылет человека во время хирургии при кровотечениях и прочей фигне более не вызывают спам ошибками в консоль сервера и лаги.
3. Смазанная бола больше не накладывает вечный неснимаемый энснейр ни при броске в цель, ни при попытках подобрать/взаимодействовать с ней.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- fix: Сервер более не лагает из-за вылетов игроков во время хирургии.
- fix: Киборги больше не могут выложить пустой слот предмета в хранилища получая руку.
- fix: Смазанная бола больше не накладывает вечный неснимаемый энснейр ни при броске в цель, ни при попытках подобрать/взаимодействовать с ней.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined placeholder system to prevent invalid operations when required hand context is unavailable, improving reliability.
  * Fixed wound severity assessment logic to eliminate redundant network synchronization events while preserving local state updates and visual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->