### PR TITLE
Update DailyRewardSystem.cs

### DIFF
--- a/Content.Server/_Mini/DailyRewards/DailyRewardSystem.cs
+++ b/Content.Server/_Mini/DailyRewards/DailyRewardSystem.cs
@@ -50,6 +50,7 @@ public sealed class DailyRewardSystem : EntitySystem
         SubscribeNetworkEvent<DailyRewardClaimRequestEvent>(OnClaimRequest);
 
         _userDb.AddOnLoadPlayer(LoadPlayerData);
+        _userDb.AddOnFinishLoad(OnPlayerDataLoaded);
         _userDb.AddOnPlayerDisconnect(OnPlayerDisconnect);
     }
 
@@ -194,6 +195,15 @@ public sealed class DailyRewardSystem : EntitySystem
             _ = _db.UpsertDailyRewardProgress(state.Progress);
 
         _states.Remove(player.UserId);
+    }
+
+    private void OnPlayerDataLoaded(ICommonSession player)
+    {
+        if (!_states.ContainsKey(player.UserId))
+            EnsureStateExists(player.UserId);
+
+        StartTracking(player);
+        SendState(player);
     }
 
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
@@ -515,6 +525,11 @@ public sealed class DailyRewardSystem : EntitySystem
             return existing;
 
         if (!_playerManager.TryGetSessionById(userId, out var session))
+            return null;
+
+        // Don't create placeholder progress before DB callbacks complete.
+        // Otherwise a quick disconnect/restart can persist a zeroed streak over real data.
+        if (!_userDb.IsLoadComplete(session))
             return null;
 
         var state = new SessionRewardState(new DailyRewardProgress


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
<!-- Что вы изменили? -->
Стрик ежедневного захода больше не должен сбрасываться при рестарте.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where daily reward progress could show incorrect or reset data during rapid disconnections or server restarts. The system now ensures reward streaks and progress data are properly synchronized with the server before being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->